### PR TITLE
Add null protection to synonym return

### DIFF
--- a/src/js/osweb/items/generic_response.js
+++ b/src/js/osweb/items/generic_response.js
@@ -250,11 +250,13 @@ export default class GenericResponse extends Item {
       return
     }
     this.experiment.vars.correct = 0
-    for (let cr of this._correct_responses) {
-      if (this.synonyms.includes(cr)) {
-        this.experiment.vars.correct = 1
-        this.experiment.vars.total_correct = this.experiment.vars.total_correct + 1
-        break
+    if(this.synonyms !== null){
+      for (let cr of this._correct_responses) {
+        if (this.synonyms.includes(cr)) {
+          this.experiment.vars.correct = 1
+          this.experiment.vars.total_correct = this.experiment.vars.total_correct + 1
+          break
+        }
       }
     }
     this.experiment.vars.total_response_time = this.experiment.vars.total_response_time + this.experiment.vars.response_time


### PR DESCRIPTION
The synonym code has recently been improved so that unrecognised keys return null, where previously they returned undefined. However, there is no protection for calls to this.synonyms in src/js/osweb/items/generic_response.js so when these unrecognised keys are returned null, the attempt to perform an array lookup on this.synonyms fails (because this.synonyms is null) and the experiment crashes.